### PR TITLE
searchbar hint SOCKS -> USDC

### DIFF
--- a/src/components/pages/Fuse/FuseTabBar.tsx
+++ b/src/components/pages/Fuse/FuseTabBar.tsx
@@ -62,7 +62,7 @@ const FuseTabBar = () => {
                 width="185px"
                 height="100%"
                 ml={2}
-                placeholder={t("Try searching for SOCKS")}
+                placeholder={t("Try searching for USDC")}
                 variant="filled"
                 size="sm"
                 _placeholder={{ color: "#e0e0e0" }}


### PR DESCRIPTION
SOCKS is not a well-known token, it's only present in one pool, and the only pool it's in also has SOCKS in the title.  Using USDC as the hint instead makes it much more clear that you can filter by tokens.

![image](https://user-images.githubusercontent.com/2591290/116896800-70046d00-abe9-11eb-9b70-3f6bbc51d4cc.png)
