### PR TITLE
Move "Positions" and "Interest Rates" into new Utilities menu

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -139,7 +139,8 @@ const App = memo(() => {
         <Route path="/fuse/pool/:poolId/info" element={<FusePoolInfoPage />} />
         <Route path="/fuse/pool/:poolId/edit" element={<FusePoolEditPage />} />
 
-        <Route path="/interest_rates" element={<InterestRatesPage />} />
+        <Route path="/interest-rates" element={<InterestRatesPage />} />
+        <Route path="/interest_rates" element={<Navigate to="/interest-rates" replace={true} />} />
 
         <Route path="/" element={<MultiPoolPortal />} />
 

--- a/src/components/pages/InterestRates/InterestRatesTable.tsx
+++ b/src/components/pages/InterestRates/InterestRatesTable.tsx
@@ -15,7 +15,6 @@ import {
 // Types
 import { MarketInfo } from "hooks/interestRates/types";
 import { TokenData } from "hooks/useTokenData";
-import { useEffect } from "react";
 
 const DEFAULT_COLUMNS: any = [
   {

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, MouseEventHandler } from "react";
+import { MouseEventHandler } from "react";
 
 import {
   Box,
@@ -80,8 +80,7 @@ export const Header = ({
         overflowY="hidden"
         transform="translate(0px, 7px)"
       >
-        {/* <HeaderLink name={t("Overview")} route="/" /> */}
-        <OverviewLink />
+        <HeaderLink name={t("Overview")} route="/" />
 
         <PoolsLink ml={3} />
 
@@ -95,9 +94,11 @@ export const Header = ({
 
         <GovernanceLink ml={4} />
 
-        {isAuthed && (
+        {/* {isAuthed && (
           <HeaderLink ml={4} name={t("Positions")} route="/positions" />
-        )}
+        )} */}
+
+        <UtilsLink ml={4} isAuthed={isAuthed} />
       </Row>
 
       <AccountButton />
@@ -105,60 +106,27 @@ export const Header = ({
   );
 };
 
-export const OverviewLink = ({ ml }: { ml?: number | string }) => {
+export const UtilsLink = ({
+  isAuthed,
+  ml,
+}: {
+  isAuthed: boolean;
+  ml?: number | string;
+}) => {
   const { t } = useTranslation();
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-  const timeoutRef = useRef<number | null>(null);
-  const [menuIsOpen, setMenuIsOpen] = useState(false);
-
-  const handleMouseOverMenu = useCallback(() => {
-    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
-    if (!menuIsOpen) buttonRef.current?.click();
-  }, [menuIsOpen]);
-
-  const handleMouseOutMenu = useCallback(() => {
-    timeoutRef.current = window.setTimeout(
-      () => buttonRef.current?.click(),
-      600
-    );
-  }, []);
-
   return (
-    <Box ml={ml ?? 0} position="relative">
-      <HeaderLink
-        name={t("Overview")}
-        route="/"
-        onMouseOver={handleMouseOverMenu}
-        onMouseOut={handleMouseOutMenu}
-        withChevron={true}
-      />
-      <Menu
-        autoSelect={false}
-        placement="bottom"
-        onOpen={() => setMenuIsOpen(true)}
-        onClose={() => setMenuIsOpen(false)}
-      >
-        <MenuButton
-          ref={buttonRef}
-          position="absolute"
-          top={0}
-          left="50%"
-          transform="translateX(-50%)"
-          pointerEvents="none"
-          aria-hidden={true}
-        >
-          &nbsp;
+    <Box ml={ml ?? 0}>
+      <Menu autoSelect={false} placement="bottom">
+        <MenuButton>
+          <SubMenuText text="Utilities" />
         </MenuButton>
 
         <Portal>
-          <MenuList
-            {...DASHBOARD_BOX_PROPS}
-            color="#FFF"
-            minWidth="110px"
-            onMouseOver={handleMouseOverMenu}
-            onMouseOut={handleMouseOutMenu}
-          >
-            <SubMenuItem name="Interest Rates" link="/interest_rates" />
+          <MenuList {...DASHBOARD_BOX_PROPS} color="#FFF" minWidth="110px">
+            {isAuthed && (
+              <SubMenuItem name={t("Positions")} link="/positions" />
+            )}
+            <SubMenuItem name="Interest Rates" link="/interest-rates" />
           </MenuList>
         </Portal>
       </Menu>


### PR DESCRIPTION
I know we discussed this in the Discord, so I'll keep this PR brief.

Essentially, I moved the Interest Rates and Positions links in the header bar into one menu called "Utilities" where the "Positions" link used to be.

Check out this [live preview](https://rari-zane-work.vercel.app/) to see this menu in action.