### PR TITLE
Add ETH override to tokenData API

### DIFF
--- a/api/tokenData.ts
+++ b/api/tokenData.ts
@@ -26,12 +26,7 @@ type tokenData = {
  *
  */
 
-<<<<<<< Updated upstream
-// params: address (required), chainId (optional) (default 1)
-export default async (request: VercelRequest, response: VercelResponse) => {
-=======
 export default async function handler(request: VercelRequest, response: VercelResponse) {
->>>>>>> Stashed changes
   response.setHeader("Access-Control-Allow-Origin", "*");
   response.setHeader("Cache-Control", "max-age=3600, s-maxage=3600");
 
@@ -96,7 +91,10 @@ export default async function handler(request: VercelRequest, response: VercelRe
 
     let method: "RARI" | "COINGECKO" | "CONTRACT";
 
-    //1.) Try Rari Token list 2.) Try Coingecko 3.) Try contracts
+    // 1.) Try Rari Token list
+    // 2.) Check if the address is the zero address (denotes ETH)
+    // 3.) Try Coingecko
+    // 4.) Try contracts
     if (!!rariTokenData) {
       // We got data from rari token list
       let { symbol: _symbol, name: _name, logoURI } = rariTokenData;
@@ -106,6 +104,10 @@ export default async function handler(request: VercelRequest, response: VercelRe
       logoURL = logoURI;
 
       method = "RARI";
+    } else if (address === "0x0000000000000000000000000000000000000000") {
+      symbol = "ETH";    // We use the zero address in the dapp to denote ETH
+      name = "Ether";
+      logoURL = "https://icons.iconarchive.com/icons/cjdowner/cryptocurrency-flat/64/Ethereum-ETH-icon.png";
     } else {
       // We could not get data from rari token list. Try Coingecko
       const coingeckoData = await fetch(coingeckoURL).then((res) => {
@@ -149,7 +151,6 @@ export default async function handler(request: VercelRequest, response: VercelRe
         method = "CONTRACT";
       }
     }
-<<<<<<< Updated upstream
   } catch (err) {
     // If it errored we should return 404
     return response.status(404).send("Nope");
@@ -170,195 +171,6 @@ export default async function handler(request: VercelRequest, response: VercelRe
     },
     overrides
   );
-=======
-  }
-
-  // On the dapp, we use 0x0 to denote raw ETH
-  if (address === "0x0000000000000000000000000000000000000000") {
-    symbol = "ETH"
-    name = "Ether"
-  }
-
-  if (
-    address ===
-    web3.utils.toChecksumAddress("0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9")
-  ) {
-    // FTX swapped the name and symbol so we will correct for that.
-    symbol = "FTT";
-    name = "FTX Token";
-  }
-
-  // OT-aUSDC
-  if (
-    address ===
-    web3.utils.toChecksumAddress("0x8fcb1783bf4b71a51f702af0c266729c4592204a")
-  ) {
-    // OT token names are too long.
-    symbol = "OT-aUSDC22";
-    name = "OT-aUSDC DEC22-20";
-  }
-
-  // OT-cDAI22
-  if (
-    address ===
-    web3.utils.toChecksumAddress("0x3d4e7f52efafb9e0c70179b688fc3965a75bcfea")
-  ) {
-    // OT token names are too long.
-    symbol = "OT-cDAI22";
-    name = "OT-cDAI DEC22-20";
-  }
-
-  // xSDT
-  if (
-    address ===
-    web3.utils.toChecksumAddress("0xaC14864ce5A98aF3248Ffbf549441b04421247D3")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/xSDT.png";
-  }
-
-  // sd3Crv
-  if (
-    address ===
-    web3.utils.toChecksumAddress("0xB17640796e4c27a39AF51887aff3F8DC0daF9567")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/sd3Crv.png";
-  }
-
-  // sdeursCRV
-  if (
-    address ===
-    web3.utils.toChecksumAddress("0xCD6997334867728ba14d7922f72c893fcee70e84")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/sdeursCRV.png";
-  }
-
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0xFD4D8a17df4C27c1dD245d153ccf4499e806C87D")
-  ) {
-    name = "linkCRV Gauge Deposit";
-    symbol = "[G]linkCRV";
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/crvLINKGauge.png";
-  }
-
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0")
-  ) {
-    name = "Wrapped Staked Ether";
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/wstETH.png";
-  }
-
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/sOHM.png";
-  }
-
-  if (symbol === "G-UNI") {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/G-UNI.png";
-  }
-
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0xe7b982f901b47d6fa21f5d1f3ad4b64c105060bf")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/spacechain/vcred-token/main/bee-256-256.png";
-  }
-
-  // Handle Token Logos
-
-  // fxAUD
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x7E141940932E3D13bfa54B224cb4a16510519308")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/fxAUDDarkLogo.png";
-  }
-
-  // fxEUD
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x116172b2482c5dc3e6f445c16ac13367ac3fcd35")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/fxEURDarkLogo.png";
-  }
-
-  // fxPHP
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x3d147cd9ac957b2a5f968de9d1c6b9d0872286a0")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/fxPHPDarkLogo.png";
-  }
-
-  // Tokemak
-  // tTOKE
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0xa760e26aA76747020171fCF8BdA108dFdE8Eb930")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tTOKE.png";
-  }
-
-  // tUSDC
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x04bDA0CF6Ad025948Af830E75228ED420b0e860d")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tUSDC.png";
-  }
-
-  // tWETH
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0xD3D13a578a53685B4ac36A1Bab31912D2B2A2F36")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tWETH.png";
-  }
-
-  // tUNILP
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x1b429e75369ea5cd84421c1cc182cee5f3192fd3")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/UniV2.png";
-  }
-
-  // tSUSHILP
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x8858A739eA1dd3D80FE577EF4e0D03E88561FaA3")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tSUSHI.png";
-  }
-
-  // txJP
-  if (
-    web3.utils.toChecksumAddress(address) ===
-    web3.utils.toChecksumAddress("0x961dd84059505d59f82ce4fb87d3c09bec65301d")
-  ) {
-    logoURL =
-      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/TXJP.png";
-  }
->>>>>>> Stashed changes
 
   // console.log({ overrides, basicTokenInfo, method });
 

--- a/api/tokenData.ts
+++ b/api/tokenData.ts
@@ -26,8 +26,12 @@ type tokenData = {
  *
  */
 
+<<<<<<< Updated upstream
 // params: address (required), chainId (optional) (default 1)
 export default async (request: VercelRequest, response: VercelResponse) => {
+=======
+export default async function handler(request: VercelRequest, response: VercelResponse) {
+>>>>>>> Stashed changes
   response.setHeader("Access-Control-Allow-Origin", "*");
   response.setHeader("Cache-Control", "max-age=3600, s-maxage=3600");
 
@@ -145,6 +149,7 @@ export default async (request: VercelRequest, response: VercelResponse) => {
         method = "CONTRACT";
       }
     }
+<<<<<<< Updated upstream
   } catch (err) {
     // If it errored we should return 404
     return response.status(404).send("Nope");
@@ -165,6 +170,195 @@ export default async (request: VercelRequest, response: VercelResponse) => {
     },
     overrides
   );
+=======
+  }
+
+  // On the dapp, we use 0x0 to denote raw ETH
+  if (address === "0x0000000000000000000000000000000000000000") {
+    symbol = "ETH"
+    name = "Ether"
+  }
+
+  if (
+    address ===
+    web3.utils.toChecksumAddress("0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9")
+  ) {
+    // FTX swapped the name and symbol so we will correct for that.
+    symbol = "FTT";
+    name = "FTX Token";
+  }
+
+  // OT-aUSDC
+  if (
+    address ===
+    web3.utils.toChecksumAddress("0x8fcb1783bf4b71a51f702af0c266729c4592204a")
+  ) {
+    // OT token names are too long.
+    symbol = "OT-aUSDC22";
+    name = "OT-aUSDC DEC22-20";
+  }
+
+  // OT-cDAI22
+  if (
+    address ===
+    web3.utils.toChecksumAddress("0x3d4e7f52efafb9e0c70179b688fc3965a75bcfea")
+  ) {
+    // OT token names are too long.
+    symbol = "OT-cDAI22";
+    name = "OT-cDAI DEC22-20";
+  }
+
+  // xSDT
+  if (
+    address ===
+    web3.utils.toChecksumAddress("0xaC14864ce5A98aF3248Ffbf549441b04421247D3")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/xSDT.png";
+  }
+
+  // sd3Crv
+  if (
+    address ===
+    web3.utils.toChecksumAddress("0xB17640796e4c27a39AF51887aff3F8DC0daF9567")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/sd3Crv.png";
+  }
+
+  // sdeursCRV
+  if (
+    address ===
+    web3.utils.toChecksumAddress("0xCD6997334867728ba14d7922f72c893fcee70e84")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/sdeursCRV.png";
+  }
+
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0xFD4D8a17df4C27c1dD245d153ccf4499e806C87D")
+  ) {
+    name = "linkCRV Gauge Deposit";
+    symbol = "[G]linkCRV";
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/crvLINKGauge.png";
+  }
+
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0")
+  ) {
+    name = "Wrapped Staked Ether";
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/wstETH.png";
+  }
+
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/sOHM.png";
+  }
+
+  if (symbol === "G-UNI") {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/G-UNI.png";
+  }
+
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0xe7b982f901b47d6fa21f5d1f3ad4b64c105060bf")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/spacechain/vcred-token/main/bee-256-256.png";
+  }
+
+  // Handle Token Logos
+
+  // fxAUD
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x7E141940932E3D13bfa54B224cb4a16510519308")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/fxAUDDarkLogo.png";
+  }
+
+  // fxEUD
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x116172b2482c5dc3e6f445c16ac13367ac3fcd35")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/fxEURDarkLogo.png";
+  }
+
+  // fxPHP
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x3d147cd9ac957b2a5f968de9d1c6b9d0872286a0")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/fxPHPDarkLogo.png";
+  }
+
+  // Tokemak
+  // tTOKE
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0xa760e26aA76747020171fCF8BdA108dFdE8Eb930")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tTOKE.png";
+  }
+
+  // tUSDC
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x04bDA0CF6Ad025948Af830E75228ED420b0e860d")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tUSDC.png";
+  }
+
+  // tWETH
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0xD3D13a578a53685B4ac36A1Bab31912D2B2A2F36")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tWETH.png";
+  }
+
+  // tUNILP
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x1b429e75369ea5cd84421c1cc182cee5f3192fd3")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/UniV2.png";
+  }
+
+  // tSUSHILP
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x8858A739eA1dd3D80FE577EF4e0D03E88561FaA3")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/tSUSHI.png";
+  }
+
+  // txJP
+  if (
+    web3.utils.toChecksumAddress(address) ===
+    web3.utils.toChecksumAddress("0x961dd84059505d59f82ce4fb87d3c09bec65301d")
+  ) {
+    logoURL =
+      "https://raw.githubusercontent.com/Rari-Capital/rari-dApp/master/src/static/tokens/TXJP.png";
+  }
+>>>>>>> Stashed changes
 
   // console.log({ overrides, basicTokenInfo, method });
 

--- a/src/constants/tokenData.ts
+++ b/src/constants/tokenData.ts
@@ -13,6 +13,12 @@ export const TokenDataOverrides: {
   };
 } = {
   [ChainID.MAINNET]: {
+    // We use the zero address in the dapp to denote ETH
+    "0x0000000000000000000000000000000000000000": {
+      symbol: "ETH",
+      name: "Ether",
+      logoURL: "https://icons.iconarchive.com/icons/cjdowner/cryptocurrency-flat/64/Ethereum-ETH-icon.png",
+    },
     // FTX
     "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9": {
       symbol: "FTT",

--- a/src/constants/tokenData.ts
+++ b/src/constants/tokenData.ts
@@ -13,12 +13,6 @@ export const TokenDataOverrides: {
   };
 } = {
   [ChainID.MAINNET]: {
-    // We use the zero address in the dapp to denote ETH
-    "0x0000000000000000000000000000000000000000": {
-      symbol: "ETH",
-      name: "Ether",
-      logoURL: "https://icons.iconarchive.com/icons/cjdowner/cryptocurrency-flat/64/Ethereum-ETH-icon.png",
-    },
     // FTX
     "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9": {
       symbol: "FTT",


### PR DESCRIPTION
Right now, the ETH logo isn't showing up correctly on https://convex-ui.vercel.app/ (screenshot below) because the API doesn't return anything for 0x0000000000000000000000000000000000000000, which is the address we use in the dapp to denote regular Ether.

<img width="1261" alt="Screen Shot 2022-03-05 at 22 40 57" src="https://user-images.githubusercontent.com/10874225/156912280-a2c7b436-13e1-4fbc-9465-ddaa8c0aa923.png">
 